### PR TITLE
Always refresh cached actor by ID, not key ID

### DIFF
--- a/fed/resolve.go
+++ b/fed/resolve.go
@@ -385,28 +385,30 @@ func (r *Resolver) tryResolveID(ctx context.Context, key httpsig.Key, u *url.URL
 		return nil, nil, fmt.Errorf("cannot resolve %s: %w", id, ErrActorNotCached)
 	}
 
-	if cachedActor != nil {
-		if cachedActor.ID != id {
-			altLockID := crc32.ChecksumIEEE([]byte(cachedActor.ID)) % uint32(len(r.locks))
-			if altLockID != lockID {
-				lock := r.locks[altLockID]
-				if err := lock.Lock(ctx); err != nil {
-					return nil, nil, err
-				}
-				defer lock.Unlock()
-			}
-		}
+	if cachedActor == nil {
+		return r.fetchActor(ctx, key, u.Host, id, cachedActor, sinceLastUpdate)
+	}
 
-		if _, err := r.db.ExecContext(
-			ctx,
-			`UPDATE persons SET fetched = UNIXEPOCH() WHERE id = ?`,
-			cachedActor.ID,
-		); err != nil {
-			return nil, cachedActor, fmt.Errorf("failed to update last fetch time for %s: %w", cachedActor.ID, err)
+	if cachedActor.ID != id {
+		altLockID := crc32.ChecksumIEEE([]byte(cachedActor.ID)) % uint32(len(r.locks))
+		if altLockID != lockID {
+			lock := r.locks[altLockID]
+			if err := lock.Lock(ctx); err != nil {
+				return nil, nil, err
+			}
+			defer lock.Unlock()
 		}
 	}
 
-	return r.fetchActor(ctx, key, u.Host, id, cachedActor, sinceLastUpdate)
+	if _, err := r.db.ExecContext(
+		ctx,
+		`UPDATE persons SET fetched = UNIXEPOCH() WHERE id = ?`,
+		cachedActor.ID,
+	); err != nil {
+		return nil, cachedActor, fmt.Errorf("failed to update last fetch time for %s: %w", cachedActor.ID, err)
+	}
+
+	return r.fetchActor(ctx, key, u.Host, cachedActor.ID, cachedActor, sinceLastUpdate)
 }
 
 func (r *Resolver) fetchActor(ctx context.Context, key httpsig.Key, host, profile string, cachedActor *ap.Actor, sinceLastUpdate time.Duration) (*ap.Actor, *ap.Actor, error) {


### PR DESCRIPTION
When fetching an actor by the public key ID, GoToSocial returns only some fields instead of returning the entire actor object.

Therefore, cached GoToSocial actors lose all their properties (like the bio) when the event that triggers refresh is verification of an incoming activity (which fetches the key) and not something else.